### PR TITLE
Fix email verification

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -32,7 +32,7 @@ def save_file():
 
 def validate_email(email):
     regex = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
-    return re.fullmatch(regex, email) and ("@innopolis.university" in email or "@innopolis.ru" in email)
+    return re.fullmatch(regex, email) and (email.endswith("@innopolis.university") or email.endswith("@innopolis.ru"))
 
 
 def send_mail(user_id):


### PR DESCRIPTION
Env:
```
❯ python3
Python 3.9.6 (default, Jun 29 2021, 06:20:32)
[Clang 12.0.0 (clang-1200.0.32.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
```

Current behaviour:
```
>>> import re
>>> email = "randomuser@innopolis.university.hack.you"
>>> def validate_email(email):
...     regex = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
...     return re.fullmatch(regex, email) and ("@innopolis.university" in email or "@innopolis.ru" in email)
...
>>> validate_email(email)
True
```

Patched:
```
>>> import re
>>> email = "randomuser@innopolis.university.hack.you"
>>> def new_validate_email(email):
...     regex = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
...     return re.fullmatch(regex, email) and (email.endswith("@innopolis.university") or email.endswith("@innopolis.ru"))
...
>>> new_validate_email(email)
False
```